### PR TITLE
pkgin up gets executed in the global zone and not inside the build zone

### DIFF
--- a/lib/mibe.inc
+++ b/lib/mibe.inc
@@ -337,8 +337,8 @@ zone_create_motdproduct() {
 }
 zone_install_packages() {
 	# First run pkgin update
-	mi_bzone_result=$(zlogin ${mi_bzone} PATH=/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin \
-            touch /opt/local/.dlj_license_accepted; pkgin -f -y up 2>&1 >> ${mi_bzone_logall} \
+	mi_bzone_result=$(zlogin ${mi_bzone} 'PATH=/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin \
+            touch /opt/local/.dlj_license_accepted; pkgin -f -y up 2>&1' >> ${mi_bzone_logall} \
             | tee -a ${mi_bzone_logall} >> ${mi_bzone_logerr} || echo $?);
 
 	[[ ! ${mi_bzone_result} ]] || failtest "Unable to update pkgin list.";


### PR DESCRIPTION
The semicolon ends the zlogin call and pkgin is executed in the global zone instead.

Quoting the complete command string will execute `pkgin up` inside the build zone.
